### PR TITLE
Add number key speed settings to visualizer (1-5)

### DIFF
--- a/visualizer.js
+++ b/visualizer.js
@@ -39,7 +39,7 @@ function showGame(game, $container, maxWidth, maxHeight, showmovement, isminimal
 
     var frame = 0;
     var transit = 0;
-    var framespersec = seconds == null ? 2.5 : game.num_frames / seconds;
+    var framespersec = seconds == null ? 3 : game.num_frames / seconds;
     var shouldplay = true;
     var xOffset = 0, yOffset = 0;
     var zoom = 8;
@@ -183,6 +183,21 @@ function showGame(game, $container, maxWidth, maxHeight, showmovement, isminimal
         else if(e.keyCode == 189 || e.keyCode == 109) { //- or - (dash or subtract)
             zoom /= 1.41421356237;
             if(zoom < 1) zoom = 1;
+        }
+        else if(e.keyCode == 49) { //1
+            framespersec = 1;
+        }
+        else if(e.keyCode == 50) { //2
+            framespersec = 3;
+        }
+        else if(e.keyCode == 51) { //3
+            framespersec = 6;
+        }
+        else if(e.keyCode == 52) { //4
+            framespersec = 10;
+        }
+        else if(e.keyCode == 53) { //5
+            framespersec = 15;
         }
     }
 


### PR DESCRIPTION
Already existent in the Halite repo visualizer, just thought I'd add them to this one as well.
Also, changes default from 2.5 fps to 3, which is how it now is in the main repo. I like it a tad better, but it doesn't matter much.